### PR TITLE
Add test for GuacamoleProtocolVersion.equals

### DIFF
--- a/guacamole-common/src/test/java/org/apache/guacamole/protocol/GuacamoleProtocolVersionTest.java
+++ b/guacamole-common/src/test/java/org/apache/guacamole/protocol/GuacamoleProtocolVersionTest.java
@@ -126,6 +126,7 @@ public class GuacamoleProtocolVersionTest {
         Assert.assertFalse(version.equals(new GuacamoleProtocolVersion(12, 102, 399)));
         Assert.assertFalse(version.equals(new GuacamoleProtocolVersion(12, 103, 398)));
         Assert.assertFalse(version.equals(new GuacamoleProtocolVersion(11, 102, 398)));
+        Assert.assertFalse(version.equals(new Object()));
 
         version = GuacamoleProtocolVersion.parseVersion("VERSION_1_0_0");
         Assert.assertTrue(version.equals(GuacamoleProtocolVersion.VERSION_1_0_0));
@@ -135,11 +136,6 @@ public class GuacamoleProtocolVersionTest {
         Assert.assertTrue(version.equals(GuacamoleProtocolVersion.VERSION_1_1_0));
         Assert.assertFalse(version.equals(GuacamoleProtocolVersion.VERSION_1_0_0));
 
-    }
-
-    @Test
-    public void testEquals() {
-        Assert.assertFalse(GuacamoleProtocolVersion.parseVersion("VERSION_012_102_398").equals(new Object()));
     }
 
     /**

--- a/guacamole-common/src/test/java/org/apache/guacamole/protocol/GuacamoleProtocolVersionTest.java
+++ b/guacamole-common/src/test/java/org/apache/guacamole/protocol/GuacamoleProtocolVersionTest.java
@@ -137,6 +137,11 @@ public class GuacamoleProtocolVersionTest {
 
     }
 
+    @Test
+    public void testEquals() {
+        Assert.assertFalse(GuacamoleProtocolVersion.parseVersion("VERSION_012_102_398").equals(new Object()));
+    }
+
     /**
      * Verifies that versions can be converted to their Guacamole protocol
      * representation through calling toString().


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that `GuacamoleProtocolVersion.parseVersion("VERSION_012_102_398").equals(new Object())` is false when equals is called with the parameters `obj = new java.lang.Object()`. 
This tests the methods [`GuacamoleProtocolVersion.equals`](https://github.com/apache/guacamole-client/blob/7f707cdb04eb079b398c1391c8d5b17c9c9bb231/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolVersion.java#L200).
The test is based on [`testValidVersionParse`](https://github.com/apache/guacamole-client/blob/7f707cdb04eb079b398c1391c8d5b17c9c9bb231/guacamole-common/src/test/java/org/apache/guacamole/protocol/GuacamoleProtocolVersionTest.java#L35).

Curious to hear what you think!

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))